### PR TITLE
Fix deploy.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
       - image: docker:17.05.0-ce-git
     working_directory: ~/repo
     steps:
+      - checkout
       - run: echo 'Running deploy job...'
       - run: |
           TAG=0.1.$CIRCLE_BUILD_NUM

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
+      - setup_remote_docker
       - run: echo 'Running deploy job...'
       - run: |
           TAG=0.1.$CIRCLE_BUILD_NUM

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
           docker_layer_caching: true
       - run: docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
       - run: echo 'Building ...'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
+          docker_layer_caching: true
+      - run: docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
       - run: echo 'Building ...'
       - run: npm install
       - run: npm test
@@ -23,8 +25,7 @@ jobs:
       - run: |
           TAG=0.1.$CIRCLE_BUILD_NUM
           docker build --tag praqma/qe-test:$TAG .
-          echo $LOREMIPSUM
-          docker login --username $DOCKER_USER --password $DOCKER_PASS
+          docker login --username $DOCKER_USER --password $DOCKER_PASS praqma/qe-test
           if [ "${CIRCLE_BRANCH}" == "master" ]; then
             docker push praqma/qe-test:$TAG
           fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,6 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
       - run: echo 'Building ...'
       - run: npm install
       - run: npm test
@@ -25,7 +24,7 @@ jobs:
       - run: |
           TAG=0.1.$CIRCLE_BUILD_NUM
           docker build --tag praqma/qe-test:$TAG .
-          docker login --username $DOCKER_USER --password $DOCKER_PASS praqma/qe-test
+          docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
           if [ "${CIRCLE_BRANCH}" == "master" ]; then
             docker push praqma/qe-test:$TAG
           fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,3 @@
-#
 version: 2
 jobs:
   build:
@@ -11,7 +10,6 @@ jobs:
       - setup_remote_docker
       - run: npm install
       - run: npm test
-
   deploy:
     docker:
       - image: docker:17.05.0-ce-git
@@ -23,13 +21,11 @@ jobs:
           docker build -t praqma/qe-test:$TAG .      # (4)
           docker login -u $DOCKER_USER -p $DOCKER_PASS         # (5)
           docker push praqma/qe-test:$TAG
-
-
 workflows:
   version: 2
-  build-deploy:
+  build-and-deploy:
     jobs:
       - build
       - deploy:
-        requires:
-          - build
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
       - run: |
           TAG=0.1.$CIRCLE_BUILD_NUM
           docker build --tag praqma/qe-test:$TAG .
+          echo $LOREMIPSUM
           docker login --username $DOCKER_USER --password $DOCKER_PASS
           if [ "${CIRCLE_BRANCH}" == "master" ]; then
             docker push praqma/qe-test:$TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
+      - run: echo 'Building ...'
       - run: npm install
       - run: npm test
   deploy:
@@ -16,13 +17,16 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      - setup_remote_docker
-      - run: echo 'Running deploy job...'
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run: echo 'Deploying ...'
       - run: |
           TAG=0.1.$CIRCLE_BUILD_NUM
-          docker build -t praqma/qe-test:$TAG .      # (4)
-          docker login -u $DOCKER_USER -p $DOCKER_PASS         # (5)
-          docker push praqma/qe-test:$TAG
+          docker build --tag praqma/qe-test:$TAG .
+          docker login --username $DOCKER_USER --password $DOCKER_PASS
+          if [ "${CIRCLE_BRANCH}" == "master" ]; then
+            docker push praqma/qe-test:$TAG
+          fi
 workflows:
   version: 2
   build-and-deploy:


### PR DESCRIPTION
* Fix indentation in deploy workflow. 🔍
* Push image only on master branch.

* _Mandatory_: Update the `$DOCKER_USERNAME` and `$DOCKER_PASSWORD` environment variables under CircleCI for the project.
* _Optional_: Use `docker_layer_caching` under `setup_remote_docker`.
* _Suggestion_: Use `$TAG-$CIRCLE_BRANCH` instead of `$TAG` if we want to test Docker images that was built on the branches too.